### PR TITLE
Add support to balance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ Modify your compile of Nginx by adding the following directive
     }
 
 	  sticky [hash=index|md5|sha1] [no_fallback] [transfer] [delimiter=.]
-           [name=route] [domain=.foo.bar] [path=/] [expires=1h] [secure] [httponly];
+           [name=route] [domain=.foo.bar] [path=/] [expires=1h] [secure] [httponly]
+           [balanced balanced_header=Sec-Fetch-Dest balanced_value=document];
        or
 	  sticky [hmac=md5|sha1 hmac_key=<foobar_key>] [no_fallback] [transfer] [delimiter=.]
-           [name=route] [domain=.foo.bar] [path=/] [expires=1h] [secure] [httponly];
+           [name=route] [domain=.foo.bar] [path=/] [expires=1h] [secure] [httponly]
+           [balanced balanced_header=Sec-Fetch-Dest balanced_value=document];
        or
 	  sticky [text=raw] [no_fallback] [transfer] [delimiter=.]
-           [name=route] [domain=.foo.bar] [path=/] [expires=1h] [secure] [httponly];
+           [name=route] [domain=.foo.bar] [path=/] [expires=1h] [secure] [httponly]
+           [balanced balanced_header=Sec-Fetch-Dest balanced_value=document];
 
 Server selection algorithm:
 - `hash`: the hash mechanism to encode upstream server. It can't be used with hmac or text.  
@@ -121,6 +124,10 @@ Cookie settings:
   This is to use cookies exclusively for routing only.  
   You can set it to the upstream block, or set `sticky_hide_cookie` in a server or
   location block.
+
+Balanced mode settings (Suitable for JSF applications):
+- `balanced`: enable balanced mode, thus sessions will be balanced between upstream servers when servers number changes
+- `balanced_header` and `balanced_value`: header name and value which will be used to trigger new sessions to any instance using round robin
 
 # Detail Mechanism
 


### PR DESCRIPTION
### Use Case
We have an environment (a JSF application) where the upstream servers count changes from time to time, based on different criteria, thus already existing sticky sessions won't be moved to new servers. This leaves the newly added server with no sessions (unless new browsers are used).


### Available Solutions
The current implementation provides the following solutions to the previous issue.
#### 1. Load balancer time-limited sessions
We can use the cookie expiry property to set an expiry date for sessions.
Disadvantages: Once the cookie is expired, the session might be closed which will lead to some errors on the application level.
#### 2. Application time-limited sticky sessions
The application can unset the cookie value whenever it's suitable so no errors occur on the application level.
Disadvantages: Handling sessions should be on the application level, this is the load balancer's responsibility.


### Proposed Solution
This PR adds the ability to detect the proper moment based on application behavior to create new sticky sessions with different upstream servers, using round-robin, and without causing the application to fail.