### PR TITLE
Fix for nginx 1.24.0

### DIFF
--- a/ngx_http_sticky_misc.c
+++ b/ngx_http_sticky_misc.c
@@ -17,11 +17,11 @@
 #endif
 
 /* - fix for 1.11.2 removes include <openssl/md5.h> in ngx_md5.h */
+#ifndef MD5_CBLOCK
 #define MD5_CBLOCK  64
 #define MD5_LBLOCK  (MD5_CBLOCK/4)
 #define MD5_DIGEST_LENGTH 16
-#define SHA_CBLOCK 64
-#define SHA_DIGEST_LENGTH 20
+#endif
 
 #ifndef SHA_DIGEST_LENGTH
 #define SHA_CBLOCK 64

--- a/ngx_http_sticky_module.c
+++ b/ngx_http_sticky_module.c
@@ -240,7 +240,13 @@ static ngx_int_t ngx_http_init_sticky_peer(ngx_http_request_t *r, ngx_http_upstr
 	ngx_http_set_ctx(r, iphp, ngx_http_sticky_module);
 
 	/* check weather a cookie is present or not and save it */
+	
+#if defined(nginx_version) && nginx_version >= 1023000
+	/* nginx-1.23.0+ compatibility */
+	if (ngx_http_parse_multi_header_lines(r, r->headers_in.cookie, &iphp->sticky_conf->cookie_name, &route) != NULL) {
+#else
 	if (ngx_http_parse_multi_header_lines(&r->headers_in.cookies, &iphp->sticky_conf->cookie_name, &route) != NGX_DECLINED) {
+#endif
 		/* a route cookie has been found. Let's give it a try */
 		ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "[sticky/init_sticky_peer] got cookie route=%V, let's try to find a matching peer", &route);
 
@@ -472,7 +478,12 @@ static ngx_int_t ngx_http_sticky_header_filter(ngx_http_request_t *r)
 	}
 
 	if (ctx->sticky_conf->transfer_cookie) {
+	#if defined(nginx_version) && nginx_version >= 1023000
+		/* nginx-1.23.0+ compatibility */
+		if (ngx_http_parse_set_cookie_lines(r, r->upstream->headers_in.set_cookie, &ctx->sticky_conf->cookie_name, &transfer_cookie) == NULL)
+	#else
 		if (ngx_http_parse_set_cookie_lines(&r->upstream->headers_in.cookies, &ctx->sticky_conf->cookie_name, &transfer_cookie) == NGX_DECLINED)
+	#endif
 		{
 			ngx_str_null(&transfer_cookie);
 		}


### PR DESCRIPTION
The module need to be adjust to work with nginx 1.23.0+.
And fix macro redefined compile error.

See:
https://trac.nginx.org/nginx/ticket/2358
https://trac.nginx.org/nginx/changeset/ef6a3a99a81a

Resolve issue: https://github.com/Refinitiv/nginx-sticky-module-ng/issues/14